### PR TITLE
Add forum SSO support

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@olinfo/react-components": "^0.7",
     "@olinfo/tailwind": "^0.1",
     "@olinfo/terry-api": "^0.1",
-    "@olinfo/training-api": "^0.3",
+    "@olinfo/training-api": "^0.4",
     "@shikijs/monaco": "^1.5",
     "@types/d3-drag": "^3.0",
     "@types/d3-force": "^3.0",

--- a/src/app/sso/page.tsx
+++ b/src/app/sso/page.tsx
@@ -1,0 +1,25 @@
+import { getForumSso } from "@olinfo/training-api";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+type Props = {
+  searchParams: { sso: string; sig: string };
+};
+
+export default async function Page({ searchParams: { sso: payload, sig: signature } }: Props) {
+  const token = cookies().get("training_token")?.value;
+
+  // User is logged out.
+  if (token === undefined) {
+    const redirectUrl = `/sso?sso=${payload}&sig=${signature}`;
+    redirect(`/login?redirect=${encodeURIComponent(redirectUrl)}`);
+  }
+
+  const { return_sso_url: returnSsoUrl, parameters } = await getForumSso(
+    payload,
+    signature,
+    `training_token=${token}`,
+  );
+
+  redirect(`${returnSsoUrl}?${parameters}`);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -713,10 +713,10 @@
     zod "^3.22"
     zod-validation-error "^3.0"
 
-"@olinfo/training-api@^0.3":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@olinfo/training-api/-/training-api-0.3.0.tgz#390501ee0dc2599a3a651d632bb1b1085f2a9bfa"
-  integrity sha512-HFzB7rJMFOYeONPh6nF9qmnlrTDQO4X7hxzAWsau7mUS0MJiW8bmf8wfDLtQ0P3X/ea0kKPpS4OBDF+5QuHtOQ==
+"@olinfo/training-api@^0.4":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@olinfo/training-api/-/training-api-0.4.0.tgz#3ff3c5094695ffd042d6b32b8659372c3f81efe9"
+  integrity sha512-R/I+lk4ghFyMILDra30FbjUdctzILS5rAyJUfXZOLqXHQHzhcJpz+nYB5rMyLujBs8uEUClrVMf+bpWREH+jUA==
   dependencies:
     jwt-decode "^4.0"
     zod "^3.22"


### PR DESCRIPTION
Implemented as a server component rather than client component, in this way we can get the answer from the backend and redirect the user immediately to discourse, without the brief UI flash.

Having the login in its own page unlike in the old frontend, and with support for `?redirect=` too, comes in handy here as we don't need anymore the toast saying "Please login in the main website first": we can now elegantly use the `/login` route with a proper `?redirect` parameter.

- [x] Requires https://github.com/algorithm-ninja/cmsocial/pull/37 to be merged first
- [x] Requires https://github.com/olimpiadi-informatica/js-libraries/pull/4 to be merged first