### PR TITLE
Hide navpanes from PDF by default

### DIFF
--- a/src/app/(training)/task/[name]/page.tsx
+++ b/src/app/(training)/task/[name]/page.tsx
@@ -42,7 +42,7 @@ export default function Page({ params }: Props) {
             supportsPDFs ? (
               <object
                 title={_(msg`Testo di ${task.title}`)}
-                data={statement}
+                data={`${statement}#navpanes=0`}
                 className="size-full"
               />
             ) : (


### PR DESCRIPTION
When including a PDF via `<object>`, this navpane is open by default:

<img width="1292" alt="image" src="https://github.com/user-attachments/assets/f41f92c7-cfbd-4657-840b-1f6358ed6879">

With this change we close it by default:

<img width="1289" alt="image" src="https://github.com/user-attachments/assets/de83dda5-214d-4ff9-879c-7998c101ed15">

This gives us more space for the actual statement.

There are [more options we could use](https://stackoverflow.com/a/2105095/747654) and as tempting as `toolbar=0` is, it is not very accessible (no obvious way to zoom in/out) so I think `navpanes=0` is a safer option.
